### PR TITLE
Updated to work on modern svelte docs. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ svelte.docset
 yarn.lock
 yarn-error.log
 .DS_Store
+svelte.docset.zip
+dataKit
+kit.svelte.dev
+sveltekit.docset

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Svelte Docset
 
-[Dash](https://kapeli.com/dash) docset documentation generator for the [Svelte](https://svelte.dev) JavaScript framework.
+[Dash](https://kapeli.com/dash) docset documentation generator for the [Svelte](https://svelte.dev) [SvelteKit](https://kit.svelte.dev)  JavaScript frameworks
 
 ## Prerequisites
 
@@ -9,15 +9,17 @@
 ## Generating the docset
 
 1. `npm install`
-2. `npm run generate` (this will both fetch & generate the docset)
+2. `npm run generate` (this will both fetch & generate the docsets)
 
-If you just want to fetch the site, `npm run fetch`.
+If you just want to fetch the sites, `npm run fetch`.
 
-If you just want to (re)build the docset, `npm run build`.
+If you just want to (re)build the docsets, `npm run build`.
+
+To generate a docset for just svelte or just sveltekit, use `npm run (generate|fetch|build)-(svelte|sveltekit)`
 
 ## Notes / About
 
-This runs a Node script and uses [Puppetteer](https://github.com/puppeteer/puppeteer) to fetch a few key pages from the main Svelte site (the tutorial + main docs page).
+This runs a Node script and uses [Puppetteer](https://github.com/puppeteer/puppeteer) to fetch a few key pages from the main Svelte site (the tutorial + main docs page) or the sveltekit docs.
 
 It then does some light processesing to setup the pages for local access -- removes the header, makes some CSS tweaks, fixes url/href paths, etc.
 
@@ -29,7 +31,7 @@ Feel free to contribute any fixes/improvements. PRs always welcome. Ideas welcom
 
 ## Things to improve / TODOs
 
-- [ ] Add [Sapper](https://sapper.svelte.dev) docs (will likely be in a separate repo)
+- [X] Add [SvelteKit](https://sapper.svelte.dev) docs (will likely be in a separate repo)
 - [ ] Get scripts / REPL working.
 - [ ] Recursion in `crawl()` makes fans spin.
 - [ ] fonts/SVGs fail on every 3rd or 4th page. Not really a big deal since they arrive the first time around
@@ -38,3 +40,4 @@ Feel free to contribute any fixes/improvements. PRs always welcome. Ideas welcom
 ## Author
 
 - [Noah Lehmann-Haupt](https://github.com/noahlh)
+- [Julie](https://github.com/cobular)

--- a/dashing-svelte.json
+++ b/dashing-svelte.json
@@ -6,66 +6,90 @@
     "h2": [
       {
         "type": "Section",
-        "matchpath": "tutorial\\/.+\\/.+\\.html"
+        "matchpath": "tutorial\\/.+\\/.+\\.html",
+        "regexp": "permalink",
+        "replacement": ""
       },
       {
         "type": "Section",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       }
     ],
     "h3": [
       {
         "type": "Tag",
         "requiretext": "^<.+>",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       },
       {
         "type": "Tag",
         "requiretext": "^{.+}",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       },
       {
         "type": "Section",
         "requiretext": "^[^svelte.\\W](\\w+\\s*)*",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       },
       {
         "type": "Module",
         "requiretext": "^svelte\\/*\\w*$",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       },
       {
         "type": "Function",
         "requiretext": "^svelte\\.+\\w*$",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       }
     ],
     "h4": [
       {
         "type": "Directive",
         "requiretext": "^\\w*\\s*:+.*$",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       },
       {
         "type": "Tag",
         "requiretext": "^<.+>",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       },
       {
         "type": "Function",
         "requiretext": "^[a-z$]\\w*$",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       },
       {
         "type": "Section",
         "requiretext": "^[A-Z](?:\\w*\\s*)*$",
-        "matchpath": "docs\\/index.html+"
+        "matchpath": "docs\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
       }
     ],
     "meta[name='Description']": {
       "type": "Guide",
       "attr": "content",
-      "matchpath": "tutorial\\/.+\\/.+\\.html"
+      "matchpath": "tutorial\\/.+\\/.+\\.html",
+      "regexp": "permalink",
+      "replacement": ""
     }
   },
   "ignore": ["ABOUT"],

--- a/dashing-sveltekit.json
+++ b/dashing-sveltekit.json
@@ -1,0 +1,172 @@
+{
+  "name": "Sveltekit",
+  "package": "sveltekit",
+  "index": "./kit.svelte.dev/docs/index.html",
+  "selectors": {
+    "h1": "Section",
+    "h3": [
+      {
+        "type": "Category",
+        "matchpath": "docs\\/web-standards\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "File",
+        "matchpath": "docs\\/routing\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/advanced-routing\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/load\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/form-actions\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/hooks\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/server-only-modules\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Module",
+        "matchpath": "docs\\/modules\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Attrbute",
+        "matchpath": "docs\\/link-options \\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/adapters\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Global",
+        "matchpath": "docs\\/page-options\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/packaging\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/cli\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Property",
+        "matchpath": "docs\\/configuration\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Module",
+        "matchpath": "docs\\/types\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/seo\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/assets\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/accessibility\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/appendix\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      }
+    ],
+    "h4": [
+      {
+        "type": "File",
+        "matchpath": "docs\\/routing\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Property",
+        "matchpath": "docs\\/load\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/form-actions\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Function",
+        "matchpath": "docs\\/hooks\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Function",
+        "matchpath": "docs\\/modules\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Type",
+        "matchpath": "docs\\/types\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      },
+      {
+        "type": "Category",
+        "matchpath": "docs\\/seo\\/index.html+",
+        "regexp": "permalink",
+        "replacement": ""
+      }
+    ]
+  },
+  "ignore": ["ABOUT"],
+  "icon32x32": "./svelte.dev/favicon.png",
+  "allowJS": true,
+  "ExternalURL": "https://svelte.dev/docs/"
+}

--- a/getSvelte.js
+++ b/getSvelte.js
@@ -20,7 +20,7 @@ async function fetchSvelte() {
 
   await page.goto("https://svelte.dev/favicon.png", { waitUntil: "networkidle0" });
 
-  // await crawl({ page, url: "tutorial/basics", pathModifier: "../../" });
+  await crawl({ page, url: "tutorial/basics", pathModifier: "../../" });
   await crawl({ page, url: "docs", pathModifier: "../" });
 
   console.log(`All done!  Closing browser`);

--- a/getSvelte.js
+++ b/getSvelte.js
@@ -2,6 +2,7 @@ const puppeteer = require("puppeteer");
 const { URL } = require("url");
 const fse = require("fs-extra");
 const path = require("path");
+const { time } = require("console");
 const fullBasePath = path.resolve("svelte.dev");
 const baseUrl = "https://svelte.dev/";
 
@@ -11,19 +12,24 @@ async function fetchSvelte() {
   console.log("Loading headless browser");
   let browser = await puppeteer.launch({ userDataDir: "./data" });
 
+
+  /** @type {puppeteer.Page} */
   let page = await browser.newPage();
   page.on("response", handleAssets);
   page.on("console", (msg) => console.log(msg.text()));
 
   await page.goto("https://svelte.dev/favicon.png", { waitUntil: "networkidle0" });
 
-  await crawl({ page, url: "tutorial/basics", pathModifier: "../../" });
+  // await crawl({ page, url: "tutorial/basics", pathModifier: "../../" });
   await crawl({ page, url: "docs", pathModifier: "../" });
 
   console.log(`All done!  Closing browser`);
   browser.close();
 }
 
+/**
+ * @param {puppeteer.HTTPResponse} response
+ */
 async function handleAssets(response) {
   console.log(`Response:  code ${response.status()} URL: ${response.url()}`);
   if (isRedirect(response.status())) return;
@@ -37,7 +43,8 @@ async function handleAssets(response) {
   try {
     let responseBuffer = await response.buffer();
   } catch (e) {
-    console.log(`Failed to load response for ${url.pathname}: ${e.message}`);
+    if (!url.pathname.includes(".woff2"))
+     console.log(`Failed to load response for ${url.pathname}: ${e.message}`);
     return;
   }
 
@@ -52,26 +59,35 @@ function isRedirect(status) {
   return status >= 300 && status <= 399;
 }
 
+/**
+ * @param {string} fullFilePath
+ * @param {string} file
+ */
 async function writeFileToDisk(fullFilePath, file) {
   await fse.outputFile(fullFilePath, file);
 }
 
 function updateCss({ buffer, fullFilePath }) {
-  return (
-    buffer
-      .toString()
-      // Fix relative paths for client/ fonts/ and icons/ in CSS URLs
-      .replace(/(?<=url\(\'?)(?:\/?client|\/?fonts|\/?icons).+?(?=\'?\))/g, (match, offset, original) => {
-        return path.relative(path.dirname(fullFilePath), path.join(fullBasePath, match));
-      })
-      // Fix padding to adjust for removed nav bar
-      .replace(/--nav-h:\s*.+;/g, "--nav-h: 0.1px;")
-  );
+  return buffer
+    .toString()
+    // Fix relative paths for client/ fonts/ and icons/ in CSS URLs
+    .replace(/(?<=url\(\'?)(?:\/?client|\/?fonts|\/?icons).+?(?=\'?\))/g, (match, offset, original) => {
+      return path.relative(path.dirname(fullFilePath), path.join(fullBasePath, match));
+    })
+    // Fix padding to adjust for removed nav bar
+    .replace(/--nav-h:\s*.+;/g, "--nav-h: 0.1px;");
 }
 
+/**
+ * Returns the sum of all numbers passed to the function.
+ * @param {{page: puppeteer.Page, url: string, pathModifier: string }} page A positive or negative number
+ */
 async function crawl({ page, url, pathModifier }) {
-  console.log(`Loading ${baseUrl + url}`);
-  await page.goto(baseUrl + url, { waitUntil: "networkidle2" });
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  let full_url = new URL(url, baseUrl)
+  console.log(`## CRAWLING ${full_url}`);
+  await page.goto(full_url, { waitUntil: "networkidle2" });
+  await new Promise(resolve => setTimeout(resolve, 1000));
 
   console.log(`Finding next tutorial page to crawl`);
   let nextUrl = await page.evaluate(findNextPage);
@@ -101,20 +117,36 @@ async function findNextPage() {
 }
 
 async function updateHtml({ pathModifier }) {
+  console.log(`Updating HTML ${pathModifier}, ${document.location.href}`);
+  // Force some variable overrides on the body
+  document.body.style = {
+    "--linemax": "1000ch",
+    "--nav-h": "0",
+  }
+  let main_content = document.querySelector("div.content");
+  if (main_content) main_content.style = "padding: var(--top-offset) var(--side-nav);"
+
   // The <base> tag needs an absolute path to work locally (we don't have that), so we're removing it
   let baseTag = document.querySelector("base");
-  baseTag.parentNode.removeChild(baseTag);
-
+  console.log(`Base tag: ${baseTag}`);
+  if (baseTag !== null) baseTag.parentNode.removeChild(baseTag);
+  
   // Stripping out the <header> since we don't want to navigate outside the docset
-  let headerTag = document.querySelector("header");
-  headerTag.parentNode.removeChild(headerTag);
+  let headerTag = document.querySelector("nav");
+  if (headerTag !== null) headerTag.parentNode.removeChild(headerTag);
 
+  let sideTag = document.querySelector("aside");
+  if (sideTag !== null) sideTag.parentNode.removeChild(sideTag);
+
+  console.log("Links")
   // Find all <link> tags and rewrite path
   rewritePaths({ tag: "link", attribute: "href" });
 
+  console.log("Scripts")
   // Find all <script> tags and rewrite path
   rewritePaths({ tag: "script", attribute: "src" });
 
+  console.log("A")
   // Find all <a> tags and re-write the href to have the proper relative path
   rewritePaths({ tag: "a", attribute: "href" });
 
@@ -132,7 +164,7 @@ async function updateHtml({ pathModifier }) {
         newValue = await window.pathJoin(pathModifier, originalAttributeValue, "/index.html");
       }
 
-      console.log(`${originalAttributeValue} -> ${newValue}`);
+      console.log(`  ${originalAttributeValue} -> ${newValue}`);
       _tag.setAttribute(attribute, newValue);
     });
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "fs-extra": "^9.0.1",
-    "puppeteer": "^4.0.0"
+    "puppeteer": "18.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "1.0.0",
   "main": "getSvelte.js",
   "scripts": {
-    "fetch": "node getSvelte.js",
-    "build": "dashing build --config dashing-svelte.json --source svelte.dev",
-    "generate": "npm run fetch && npm run build"
+    "fetch-svelte": "node getSvelte.js",
+    "fetch-sveltekit": "node getSvelteKit.js",
+    "build-svelte": "dashing build --config dashing-svelte.json --source svelte.dev",
+    "build-sveltekit": "dashing build --config dashing-sveltekit.json --source kit.svelte.dev",
+    "generate-svelte": "npm run fetch-svelte && npm run build-svelte",
+    "generate-sveltekit": "npm run fetch-sveltekit && npm run build-sveltekit",
+    "generate": "npm run generate-svelte && npm run generate-sveltekit"
   },
   "author": "Noah Lehmann-Haupt <nlh@nlh.me>",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,388 @@
+lockfileVersion: 5.4
+
+specifiers:
+  fs-extra: ^9.0.1
+  puppeteer: 18.0.3
+
+dependencies:
+  fs-extra: 9.1.0
+  puppeteer: 18.0.3
+
+packages:
+
+  /@types/node/18.7.18:
+    resolution: {integrity: sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==}
+    dev: false
+    optional: true
+
+  /@types/yauzl/2.10.0:
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
+    requiresBuild: true
+    dependencies:
+      '@types/node': 18.7.18
+    dev: false
+    optional: true
+
+  /agent-base/6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /at-least-node/1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
+    dev: false
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /base64-js/1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /bl/4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: false
+
+  /brace-expansion/1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: false
+
+  /buffer-crc32/0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+    dev: false
+
+  /buffer/5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
+
+  /chownr/1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    dev: false
+
+  /concat-map/0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: false
+
+  /cross-fetch/3.1.5:
+    resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
+    dependencies:
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /debug/4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
+  /devtools-protocol/0.0.1036444:
+    resolution: {integrity: sha512-0y4f/T8H9lsESV9kKP1HDUXgHxCdniFeJh6Erq+FbdOEvp/Ydp9t8kcAAM5gOd17pMrTDlFWntoHtzzeTUWKNw==}
+    dev: false
+
+  /end-of-stream/1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    dependencies:
+      once: 1.4.0
+    dev: false
+
+  /extract-zip/2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+    dependencies:
+      debug: 4.3.4
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /fd-slicer/1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+    dependencies:
+      pend: 1.2.0
+    dev: false
+
+  /fs-constants/1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    dev: false
+
+  /fs-extra/9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: false
+
+  /fs.realpath/1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: false
+
+  /get-stream/5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+    dependencies:
+      pump: 3.0.0
+    dev: false
+
+  /glob/7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: false
+
+  /graceful-fs/4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+    dev: false
+
+  /https-proxy-agent/5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ieee754/1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: false
+
+  /inflight/1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: false
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /jsonfile/6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.10
+    dev: false
+
+  /minimatch/3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: false
+
+  /mkdirp-classic/0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: false
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: false
+
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
+  /once/1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: false
+
+  /path-is-absolute/1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /pend/1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    dev: false
+
+  /progress/2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
+
+  /pump/3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+    dev: false
+
+  /puppeteer/18.0.3:
+    resolution: {integrity: sha512-IiW4Zz0xbphl1lQEAB7grPucbk/aM+GND4aJ7I8gOzOSp7Ika1bz35maox4FbELpPL8sqXsVQRNrXQnzBMiCzQ==}
+    engines: {node: '>=14.1.0'}
+    requiresBuild: true
+    dependencies:
+      cross-fetch: 3.1.5
+      debug: 4.3.4
+      devtools-protocol: 0.0.1036444
+      extract-zip: 2.0.1
+      https-proxy-agent: 5.0.1
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      rimraf: 3.0.2
+      tar-fs: 2.1.1
+      unbzip2-stream: 1.4.3
+      ws: 8.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /readable-stream/3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /rimraf/3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+    dev: false
+
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
+
+  /string_decoder/1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /tar-fs/2.1.1:
+    resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.0
+      tar-stream: 2.2.0
+    dev: false
+
+  /tar-stream/2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.4
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: false
+
+  /through/2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+    dev: false
+
+  /tr46/0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
+  /unbzip2-stream/1.4.3:
+    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
+    dependencies:
+      buffer: 5.7.1
+      through: 2.3.8
+    dev: false
+
+  /universalify/2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
+    dev: false
+
+  /util-deprecate/1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false
+
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false
+
+  /wrappy/1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: false
+
+  /ws/8.8.1:
+    resolution: {integrity: sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
+  /yauzl/2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+    dev: false


### PR DESCRIPTION
Updated everything to work on the modern version of the svelte docs. Please find the generated docset attached. 

Major changes:

1. Removed left column because IMO it doesn't add much given that we already have the TOC right there
2. Removed `permalink` text from every key - I guess they changed smth that caused that to appear


Known issues:
1. Examples don't appear in main page TOC, making them hard to discover a little bit (I think this was an issue before - don't reallyyyy care about fixing it too much)

[svelte.docset.zip](https://github.com/noahlh/svelte-dash-docset/files/9610806/svelte.docset.zip)
